### PR TITLE
Fix V773 warning from PVS-Studio Static Analyzer

### DIFF
--- a/src/lvdocommon.h
+++ b/src/lvdocommon.h
@@ -61,8 +61,10 @@ static inline unsigned int *new_zigzag_reverse(unsigned int size) {
     unsigned int *zigzag_index = new_zigzag_index(size);
     unsigned int *zigzag_reverse = g_malloc_n(size*size, sizeof (unsigned int));
     unsigned int i;
-    if(size == 0)
+    if(size == 0) {
+        g_free(zigzag_reverse);
         return zigzag_index;
+    }
     for(i = 0; i < size*size; i++)
         zigzag_reverse[zigzag_index[i]] = i;
     g_free(zigzag_index);

--- a/src/lvdoenc.c
+++ b/src/lvdoenc.c
@@ -41,6 +41,8 @@ int lvdo_dispatch(FILE *fi, FILE *fo, unsigned int blocksize, unsigned int quant
         g_printerr("lvdo: [info] bytes per frame: %lu\n", (unsigned long) payloadlen);
     else {
         g_printerr("lvdo: [error] bytes per frame: 0\n");
+        fftw_free(in); fftw_free(out); fftw_destroy_plan(plan);
+        g_free(payload); g_free(framey); g_free(frameuv); g_free(zigzag_reverse);
         return 1;
     }
     while(!feof(fi)) {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
V773 The function was exited without releasing a pointer.
A memory leak is possible.